### PR TITLE
Updated Bc -> tau nu branching fraction to final value used in paper

### DIFF
--- a/case-studies/flavour/Bc2TauNu/calc_BFs.py
+++ b/case-studies/flavour/Bc2TauNu/calc_BFs.py
@@ -65,7 +65,7 @@ for nz in number_of_zs:
 
     #Theory expectation for Bc -> tau nu (not so important, just sets the level of expected signal and our central value estimated BF)
     #Olcyr value from paper
-    BF_Bc2TauNu_expected = 2.21e-2
+    BF_Bc2TauNu_expected = 1.94e-2
 
     #Full efficiency of Bc -> tau nu analysis, known to 1% uncertainty
     #Read value from optimisation

--- a/case-studies/flavour/Bc2TauNu/estimate_purity.py
+++ b/case-studies/flavour/Bc2TauNu/estimate_purity.py
@@ -83,7 +83,7 @@ def run(nz):
             print(N_bkg_tot[f"{b}_{d}"])
 
     #Olcyr calculation of BF(Bc -> tau nu)
-    BF_Bc2TauNu = 2.21e-2
+    BF_Bc2TauNu = 1.94e-2
     #PDG values
     BF_Bu2TauNu = 1.09e-4
     BF_Tau23Pi = 0.0931


### PR DESCRIPTION
Updated code and results to match the BF(Bc -> tau nu) = 1.94% value from Olcyr that is used in the paper.